### PR TITLE
fix: double scrollbar when video is not chosen

### DIFF
--- a/src/app/home/course/course.page.html
+++ b/src/app/home/course/course.page.html
@@ -61,7 +61,7 @@
                     </ion-list>
                 </ng-container>
             </ion-col>
-            <ion-col size="12" class="scroll-area" size-lg>
+            <ion-col size="12" size-lg [ngClass]="currentVideo ? 'scroll-area' : ''">
                 <ion-list *ngIf="list$ | async as list">
                     <ion-item button *ngFor="let lecture of list | keyvalue trackBy: lectureById" (click)="viewVideo(lecture.value)"
                               [color]="(currentVideo && currentVideo.id && currentVideo.id === lecture.value.id) ? 'secondary' : ''">


### PR DESCRIPTION
Reproducible on iPad Air (5th generation) with Safari on iPadOS 17.2
![IMG_6110](https://github.com/docchula/FlickPlayer/assets/39715559/178f4d35-8ef0-41a7-99ff-7430540cd0c7)
